### PR TITLE
fix: SSR hydration error caused by useId

### DIFF
--- a/packages/vant/src/composables/use-id.ts
+++ b/packages/vant/src/composables/use-id.ts
@@ -1,9 +1,13 @@
-import { getCurrentInstance } from 'vue';
+import { getCurrentInstance, inject } from 'vue';
 
-let current = 0;
+const initial = { current: 0 };
+const ID_INJECTION_KEY = 'van-id-injection';
 
 export function useId() {
   const vm = getCurrentInstance();
+  const idInjection = getCurrentInstance()
+    ? inject(ID_INJECTION_KEY, initial)
+    : initial;
   const { name = 'unknown' } = vm?.type || {};
 
   // keep test snapshot stable
@@ -11,5 +15,11 @@ export function useId() {
     return name;
   }
 
-  return `${name}-${++current}`;
+  if (typeof window === 'undefined' && !inject(ID_INJECTION_KEY)) {
+    console.warn(
+      '[vant useId] Looks like you are using server rendering, we suggest injecting an initial value for the ID. eg: app.provide("van-id-injection", { current: 0 })',
+    );
+  }
+
+  return `${name}-${++idInjection.current}`;
 }


### PR DESCRIPTION
Before submitting a pull request, please read the [contributing guide](https://vant-contrib.gitee.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-contrib.gitee.io/vant/#/zh-CN/contribution)。

目前使用Vite5的SSR项目都可能会出现：刷新后 服务端的id一直自增，而客户端从0开始而引起水合错误 (如：#12548)

这个PR是让SSR用户注入一个初始值，以避免服务端id一直自增

---

我原本是想将 `ID_INJECTION_KEY` 导出为一个 `Symbol()`，但这似乎不好和当前的构建冲突